### PR TITLE
fix: add husky pre-commit

### DIFF
--- a/.cspell.yaml
+++ b/.cspell.yaml
@@ -1,0 +1,30 @@
+language: en_US
+words:
+  - Liatrio
+  - testid
+  - uuidv
+dictionaries:
+  - aws
+  - companies
+  - css
+  - docker
+  - html
+  - k8s
+  - markdown
+  - misc
+  - npm
+  - softwareTerms
+  - useCompounds
+ignorePaths:
+  - .gitignore
+  - .dockerignore
+  - .cspell.yaml
+  - .git/
+  - CHANGELOG.md
+  - package.json
+  - stories/
+  - node_modules/
+features:
+  weighted-suggestions: true
+allowCompoundWords: true
+useGitignore: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
       id-token: write
       contents: write
 
+    env:
+      HUSKY: 0
+
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+yarn lint:all

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,9 @@
+#!/bin/env bash
+
+set -e
+
 yarn lint:all
+
+if command -v pre-commit &> /dev/null; then
+  pre-commit run
+fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,51 @@
+default_install_hook_types: [pre-commit, pre-push, commit-msg]
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-yaml
+        args:
+          - '--allow-multiple-documents'
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.41.0
+    hooks:
+      - id: markdownlint
+        exclude: CHANGELOG.md
+        args:
+          - '--fix' # Automatically fix issues
+          - '--disable=MD013' # Ignore Line length
+          - '--disable=MD033' # Allow Inline HTML
+          - '--disable=MD034' # Allow bare URLs
+          - '--ignore=./.github/ISSUE_TEMPLATE' # Ignore issue templates
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v3.29.0
+    hooks:
+      - id: commitizen
+      - id: commitizen-branch
+        stages: [push]
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        args:
+          - '-d'
+          - '{extends: relaxed, rules: {line-length: {max: 120}}}'
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.13.3
+    hooks:
+      - id: cspell
+  - repo: local
+    hooks:
+      - id: prettier
+        name: Prettier via npm
+        entry: npm run prettier:fix
+        language: node
+        types_or: [css, javascript, ts, tsx]

--- a/package.json
+++ b/package.json
@@ -31,13 +31,15 @@
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",
     "lint": "backstage-cli package lint",
+    "lint:all": "yarn lint && yarn prettier:check",
     "test": "backstage-cli package test",
     "clean": "backstage-cli package clean",
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack",
     "prettier:check": "npx --yes prettier --check .",
     "prettier:fix": "npx --yes prettier --write .",
-    "tsc:full": "tsc --skipLibCheck true --incremental false"
+    "tsc:full": "tsc --skipLibCheck true --incremental false",
+    "prepare": "husky"
   },
   "dependencies": {
     "@backstage/core-components": "^0.14.3",
@@ -74,7 +76,9 @@
     "@testing-library/react": "^15.0.0",
     "@testing-library/user-event": "^14.0.0",
     "conventional-changelog-conventionalcommits": "^7.0.2",
+    "husky": "^9.1.6",
     "msw": "^1.0.0",
+    "pinst": "^3.0.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
     "react-router-dom": "^6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8795,6 +8795,11 @@ human-signals@^5.0.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
   integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
 
+husky@^9.1.6:
+  version "9.1.6"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.6.tgz#e23aa996b6203ab33534bdc82306b0cf2cb07d6c"
+  integrity sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==
+
 hyperdyperid@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hyperdyperid/-/hyperdyperid-1.2.0.tgz#59668d323ada92228d2a869d3e474d5a33b69e6b"
@@ -12531,6 +12536,11 @@ pify@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-5.0.0.tgz#1f5eca3f5e87ebec28cc6d54a0e4aaf00acc127f"
   integrity sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==
+
+pinst@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pinst/-/pinst-3.0.0.tgz#80dec0a85f1f993c6084172020f3dbf512897eec"
+  integrity sha512-cengSmBxtCyaJqtRSvJorIIZXMXg+lJ3sIljGmtBGUVonMnMsVJbnzl6jGN1HkOWwxNuJynCJ2hXxxqCQrFDdw==
 
 pirates@^4.0.1, pirates@^4.0.4, pirates@^4.0.6:
   version "4.0.6"


### PR DESCRIPTION
This pull request includes several changes to improve the development workflow and enforce code quality standards. The most important changes include the addition of a spell-check configuration, updates to the pre-commit hooks, and modifications to the `package.json` file to integrate Husky and other tools.

### Development Workflow Improvements:

* **Spell-check Configuration**: Added a new `.cspell.yaml` file to configure spell-checking with custom dictionaries and ignore paths. (`.cspell.yaml`, [.cspell.yamlR1-R30](diffhunk://#diff-3eb548e27a9fd5527f6ea4dfe6350d3ecde8bcf4783f92658a2f5ae847a985fdR1-R30))
* **Pre-commit Hooks**: Introduced a `.husky/pre-commit` script to run linting and pre-commit checks using `pre-commit` if available. (`.husky/pre-commit`, [.husky/pre-commitR1-R9](diffhunk://#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dR1-R9))
* **Pre-commit Configuration**: Added a `.pre-commit-config.yaml` file to define various pre-commit hooks, including checks for large files, merge conflicts, YAML validation, and markdown linting. (`.pre-commit-config.yaml`, [.pre-commit-config.yamlR1-R51](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R1-R51))

### Package Configuration:

* **Husky Integration**: Updated `package.json` to add Husky and a `prepare` script to set up Git hooks. (`package.json`, [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R34-R42) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R79-R81)
* **Linting Command**: Added a `lint:all` script to `package.json` for running both lint and Prettier checks. (`package.json`, [package.jsonR34-R42](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R34-R42))

### Miscellaneous:

* **GitHub Actions**: Updated the `release.yml` workflow to disable Husky during the release process. (`.github/workflows/release.yml`, [.github/workflows/release.ymlR22-R24](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R22-R24))