### PR TITLE
fix: updating react-dora-charts dependency to most recent, non-deprec…

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@backstage/core-plugin-api": "^1.9.1",
     "@backstage/plugin-catalog-react": "^1.12.3",
     "@backstage/theme": "^0.5.2",
-    "@liatrio/react-dora-charts": "^2.0.0",
+    "@liatrio/react-dora-charts": "1.2.0",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.61",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@backstage/core-plugin-api": "^1.9.1",
     "@backstage/plugin-catalog-react": "^1.12.3",
     "@backstage/theme": "^0.5.2",
-    "@liatrio/react-dora-charts": "1.2.0",
+    "@liatrio/react-dora-charts": "^1.2.0",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.61",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2299,10 +2299,10 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz#4fc56c15c580b9adb7dc3c333a134e540b44bfb1"
   integrity sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==
 
-"@liatrio/react-dora-charts@^1.1.8":
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/@liatrio/react-dora-charts/-/react-dora-charts-1.1.10.tgz#001e615b83c3abe17204e869ceadcdf2a77a60c6"
-  integrity sha512-CUK8JD5jGqifu3Ykx7WgXzPoR6Hulg48f5ZuizS08LG9VggRR+gAz9GNhl2co5Dg4Cyik1KGqNCHqaNVM6vBNw==
+"@liatrio/react-dora-charts@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@liatrio/react-dora-charts/-/react-dora-charts-1.2.0.tgz#8b656b3831ae59b9ab7f44fec61e2e9b010fa62d"
+  integrity sha512-npj3YXiS0bAE5fTW8ytBbLufMyPZB35DCCJ0IeEjc+fJ/f+JymUn++qkapbTv25ss+u6qwvRSbEWqmICbzf2tg==
   dependencies:
     js-yaml "^4.1.0"
     react-tooltip "^5.28.0"


### PR DESCRIPTION

Version 2.0.0 and 2.0.1 of the react-dora-charts are deprecated and should not be used. This PR updates the backstage-dora-plugin to the most recent, non-deprecated version of the react-dora-charts, which is 1.2.0. Using fix conventional commit instead of chore to trigger a new release.